### PR TITLE
 Typo: directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or install it yourself as:
 
 ### Capturing in Rails
 
-In `config/initializer/rack_vcr.rb`:
+In `config/initializers/rack_vcr.rb`:
 
 ```ruby
 if Rails.env.test?


### PR DESCRIPTION
I found it when copy-and-paste this line to create config file.

Typical Rails projects have `config/initializers` dir, not `config/initializer`.
