### PR TITLE
Fix the problem when symbol key exists in env

### DIFF
--- a/lib/rack/vcr/transaction.rb
+++ b/lib/rack/vcr/transaction.rb
@@ -46,8 +46,10 @@ module Rack
       end
 
       def headers_hash_from_env
-        fields = @req.env.select {|k, v| k.start_with? 'HTTP_' }
-                 .collect { |k, v| [normalize_header_field(k), v] }
+        fields = @req.env
+                   .map { |k, v| [k.to_s, v] }
+                   .select {|k, v| k.start_with?('HTTP_') }
+                   .collect { |k, v| [normalize_header_field(k), v] }
         Hash[fields]
       end
 


### PR DESCRIPTION
`start_with?` would fail if there was middleware that puts a symbol key in env.

e.g.
https://github.com/DataDog/dd-trace-rb/blob/af8173e14249e8b473cce2a387d9685d5ba4203d/lib/ddtrace/contrib/rack/middlewares.rb#L78
