### PR TITLE
[Do not merge] Trigger CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 2.2.0
-before_install: gem install bundler -v 1.10.3
+  - 2.4.9
+# before_install: gem install bundler -v 1.10.3


### PR DESCRIPTION
I'm opening this empty PR to see if the test suite is passing on CI. When I run it locally I'm seeing a failure:
```
$ bundle exec rake
/Users/rmacklin/.rvm/rubies/ruby-2.4.4/bin/ruby -I/Users/rmacklin/.rvm/gems/ruby-2.4.4/gems/rspec-core-3.9.1/lib:/Users/rmacklin/.rvm/gems/ruby-2.4.4/gems/rspec-support-3.9.2/lib /Users/rmacklin/.rvm/gems/ruby-2.4.4/gems/rspec-core-3.9.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

Rack::VCR with replay
  with the replay option with no VCR cassette
    does not locate cassette
  with the replay option with hardcoded VCR cassette
    locates the cassette
  with the dynamic Rack middleware to find cassette
    locates the cassette

Rack::VCR
  runs the HTTP request
  replays the cassette on Rack
  replays the cassette with webmock (FAILED - 1)
  with symbol key in env
    runs the HTTP request

Failures:

  1) Rack::VCR replays the cassette with webmock
     Failure/Error: res = Net::HTTP.get_response(URI.parse("http://ruby-lang.org/hi"))
     
     NoMethodError:
       undefined method `close' for #<StubSocket:0x00007f89e41aae08>
       Did you mean?  closed?
                      clone
     # /Users/rmacklin/.rvm/gems/ruby-2.4.4/gems/webmock-1.24.6/lib/webmock/http_lib_adapters/net_http.rb:125:in `ensure in start_without_connect'
     # /Users/rmacklin/.rvm/gems/ruby-2.4.4/gems/webmock-1.24.6/lib/webmock/http_lib_adapters/net_http.rb:125:in `start_without_connect'
     # /Users/rmacklin/.rvm/gems/ruby-2.4.4/gems/webmock-1.24.6/lib/webmock/http_lib_adapters/net_http.rb:150:in `start'
     # ./spec/rack/vcr_spec.rb:68:in `block (3 levels) in <top (required)>'
     # /Users/rmacklin/.rvm/gems/ruby-2.4.4/gems/vcr-5.1.0/lib/vcr/util/variable_args_block_caller.rb:9:in `call_block'
     # /Users/rmacklin/.rvm/gems/ruby-2.4.4/gems/vcr-5.1.0/lib/vcr.rb:188:in `use_cassette'
     # ./spec/rack/vcr_spec.rb:67:in `block (2 levels) in <top (required)>'
     # ./spec/rack/vcr_spec.rb:27:in `block (2 levels) in <top (required)>'

Finished in 0.07778 seconds (files took 0.47803 seconds to load)
7 examples, 1 failure

Failed examples:

rspec ./spec/rack/vcr_spec.rb:62 # Rack::VCR replays the cassette with webmock

/Users/rmacklin/.rvm/rubies/ruby-2.4.4/bin/ruby -I/Users/rmacklin/.rvm/gems/ruby-2.4.4/gems/rspec-core-3.9.1/lib:/Users/rmacklin/.rvm/gems/ruby-2.4.4/gems/rspec-support-3.9.2/lib /Users/rmacklin/.rvm/gems/ruby-2.4.4/gems/rspec-core-3.9.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```